### PR TITLE
doc: fix home folder path issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can now refer to `sherlock-wiki` in your `fallback.json` file like so:
         "type": "bulk_text",
         "on_return": "next",
         "async": true, 
-        "args": {"icon": "wikipedia", "exec": "/home/basti/.config/sherlock/scripts/sherlock-wiki", "exec-args": "'{keyword}'"},
+        "args": {"icon": "wikipedia", "exec": "~/.config/sherlock/scripts/sherlock-wiki", "exec-args": "'{keyword}'"},
         "priority": 0 
     }
 ```


### PR DESCRIPTION
switched in installation documentation of the fallback.json file from 
```/home/basti/.config/...``` to ```~/.config/...```  so there'll be no issues when copying it.